### PR TITLE
Fix links and submit to CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^tools$
 ^data-raw$
 ^cran-comments\.md$
+^CRAN-SUBMISSION$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,7 @@ Description: A data package containing a database of epidemiological
     parameters. It stores the data for the 'epiparameter' R package.
     Epidemiological parameter estimates are extracted from the literature.
 License: CC0
-URL: https://github.com/epiverse-trace/epiparameterDB/,
-    https://epiverse-trace.github.io/epiparameterDB/
+URL: https://github.com/epiverse-trace/epiparameterDB/
 BugReports: https://github.com/epiverse-trace/epiparameterDB/issues
 Depends: 
     R (>= 4.0.0)

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,7 +59,7 @@ data(package = "epiparameterDB")
 
 ## Contributing to library of epidemiological parameters
 
-Parameters can be added to the [JSON file holding the data](https://github.com/epiverse-trace/epiparameter/blob/main/inst/extdata/parameters.json) base directly via a Pull Request.
+Parameters can be added to the [JSON file holding the data](https://github.com/epiverse-trace/epiparameterDB/blob/main/inst/extdata/parameters.json) base directly via a Pull Request.
 
 You can find explanation of accepted entries for each column in the [data dictionary](https://github.com/epiverse-trace/epiparameterDB/blob/main/inst/extdata/data_dictionary.json).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ data(package = "epiparameterDB")
 ## Contributing to library of epidemiological parameters
 
 Parameters can be added to the [JSON file holding the
-data](https://github.com/epiverse-trace/epiparameter/blob/main/inst/extdata/parameters.json)
+data](https://github.com/epiverse-trace/epiparameterDB/blob/main/inst/extdata/parameters.json)
 base directly via a Pull Request.
 
 You can find explanation of accepted entries for each column in the

--- a/man/epiparameterDB-package.Rd
+++ b/man/epiparameterDB-package.Rd
@@ -11,7 +11,6 @@ A data package containing a database of epidemiological parameters. It stores th
 Useful links:
 \itemize{
   \item \url{https://github.com/epiverse-trace/epiparameterDB/}
-  \item \url{https://epiverse-trace.github.io/epiparameterDB/}
   \item Report bugs at \url{https://github.com/epiverse-trace/epiparameterDB/issues}
 }
 


### PR DESCRIPTION
This version is now hosted on CRAN: https://cran.r-project.org/web/packages/epiparameterDB/index.html.