### PR TITLE
Update package lifecycle status from experimental to stable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,9 @@ Authors@R: c(
     person("Adam", "Kucharski", , "adam.kucharski@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0001-8814-9421")),
     person("Carmen", "Tamayo", , "carmen.tamayo-cuartero@lshtm.ac.uk", role = "aut",
-           comment = c(ORCID = "0000-0003-4184-2864"))
+           comment = c(ORCID = "0000-0003-4184-2864")),
+    person("London School of Hygiene and Tropical Medicine, LSHTM", role = "cph",
+           comment = c(ROR = "00a0jsq62"))
   )
 Description: A data package containing a database of epidemiological
     parameters. It stores the data for the 'epiparameter' R package.

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,8 @@ knitr::opts_chunk$set(
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/mit)
 [![R-CMD-check](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/epiparameterDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameterDB?branch=main)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14514630.svg)](https://doi.org/10.5281/zenodo.14514630)
 <!-- badges: end -->
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,6 +27,8 @@ knitr::opts_chunk$set(
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14514630.svg)](https://doi.org/10.5281/zenodo.14514630)
+[![CRAN status](https://www.r-pkg.org/badges/version/epiparameterDB)](https://CRAN.R-project.org/package=epiparameterDB)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/epiparameterDB)](https://cran.r-project.org/package=epiparameterDB)
 <!-- badges: end -->
 
 `{epiparameterDB}` provides a database of epidemiological parameters. It stores the data for the `{epiparameter}` R package. 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/epiparameterDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameterDB?branch=main)
 [![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![Project Status: Active – The project has reached a stable, usable
+state and is being actively
+developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14514630.svg)](https://doi.org/10.5281/zenodo.14514630)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/epiparameterDB)](https://CRAN.R-project.org/package=epiparameterDB)
+[![CRAN
+downloads](https://cranlogs.r-pkg.org/badges/epiparameterDB)](https://cran.r-project.org/package=epiparameterDB)
 <!-- badges: end -->
 
 `{epiparameterDB}` provides a database of epidemiological parameters. It

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,8 +2,10 @@ CMD
 Codecov
 epiparameter
 Epiverse
+jsq
 Lassa
 Lifecycle
+LSHTM
 ORCID
 SARS
 doi

--- a/man/epiparameterDB-package.Rd
+++ b/man/epiparameterDB-package.Rd
@@ -11,6 +11,7 @@ A data package containing a database of epidemiological parameters. It stores th
 Useful links:
 \itemize{
   \item \url{https://github.com/epiverse-trace/epiparameterDB/}
+  \item \url{https://epiverse-trace.github.io/epiparameterDB/}
   \item Report bugs at \url{https://github.com/epiverse-trace/epiparameterDB/issues}
 }
 
@@ -22,6 +23,11 @@ Authors:
 \itemize{
   \item Adam Kucharski \email{adam.kucharski@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-8814-9421}{ORCID})
   \item Carmen Tamayo \email{carmen.tamayo-cuartero@lshtm.ac.uk} (\href{https://orcid.org/0000-0003-4184-2864}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
 }
 
 }


### PR DESCRIPTION
This PR updates the [lifecycle stage](https://lifecycle.r-lib.org/articles/stages.html) of the package from _experimental_ to _stable_ as we do not expect any upcoming major breaking changes.

Now the package is hosted on CRAN since v0.1.0, this PR adds CRAN status and CRAN downloads badges to the `README`. 

The London School of Hygiene and Tropical Medicine is added a copyright holder to the `DESCRIPTION` with an [ROR](https://ror.org/). 