### PR TITLE
Fix `update-citation-cff.yaml`

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
     paths:
-      - DESCRIPTION
-      - inst/CITATION
-      - .github/workflows/update-citation-cff.yaml
+      - 'DESCRIPTION'
+      - 'inst/CITATION'
+      - '.github/workflows/update-citation-cff.yaml'
   workflow_dispatch:
 
 name: Update CITATION.cff
@@ -55,5 +55,6 @@ jobs:
           body: |
             This pull request updates the citation file, ensuring all authors are credited and there are no discrepancies.
 
-            Please verify the changes before merging. 
+            Please verify the changes before merging.
           branch: update-citation-cff
+          add-paths: CITATION.cff

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -9,6 +9,7 @@ Lassa
 Lifecycle
 LSHTM
 ORCID
+ROR
 SARS
 Tamayo
 zenodo

--- a/man/epiparameterDB-package.Rd
+++ b/man/epiparameterDB-package.Rd
@@ -27,7 +27,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item London School of Hygiene and Tropical Medicine, LSHTM (00a0jsq62) [copyright holder]
+  \item London School of Hygiene and Tropical Medicine, LSHTM (\href{https://ror.org/00a0jsq62}{ROR}) [copyright holder]
 }
 
 }


### PR DESCRIPTION
This PR fixes the `update-citation-cff.yaml` GitHub actions workflow by adding `add-paths: CITATION.cff` to prevent the error:

```
To https://github.com/epiverse-trace/epiparameterDB
   ! [remote rejected] update-citation-cff -> update-citation-cff (refusing to allow a GitHub App to create or update workflow `.github/workflows/pkgdown.yaml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/epiverse-trace/epiparameterDB'
  Error: The process '/usr/bin/git' failed with exit code 1
  ```

This PR also contains minor miscellaneous updates:

- The paths in `update-citation-cff.yaml` are put in single quotes
- Incrementing the `RoxygenNote` in the `DESCRIPTION`
- Updating `epiparameterDB-package.Rd` with the ROR
- Updating `WORDLIST`