### PR TITLE
Miscellaneous minor updates

### DIFF
--- a/.github/workflows/validate-json.yaml
+++ b/.github/workflows/validate-json.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [main, master]
     paths:
-      - 'R/sysdata.rda'
+      - 'data/**'
       - 'inst/extdata/**'
       - 'data-raw/parameters.R'
       - '.github/workflows/validate-json.yaml'
   merge_group:
   pull_request:
     paths:
-      - 'R/sysdata.rda'
+      - 'data/**'
       - 'inst/extdata/**'
       - 'data-raw/parameters.R'
       - '.github/workflows/validate-json.yaml'

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: all_linters(
     packages = c("lintr", "etdev"),
-    pipe_consistency_linter(pipe = "%>%"),
+    pipe_consistency_linter(pipe = "|>"),
     object_name_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -29,11 +29,5 @@ exclusions: list(
     "data-raw" = list(
       missing_package_linter = Inf,
       namespace_linter = Inf
-    ),
-    # RcppExports.R is auto-generated and will not pass many linters. In
-    # particular, it can create very long lines.
-    "R/RcppExports.R",
-    # R/stanmodels.R is auto-generated and will not pass many linters. In
-    # particular, it uses `sapply()`.
-    "R/stanmodels.R"
+    )
   )

--- a/R/data.R
+++ b/R/data.R
@@ -3,7 +3,7 @@
 #' @format ## `epiparameterDB`
 #' A `list` of epidemiological parameters read from `extdata/parameters.json`
 #' with `r length(epiparameterDB::epiparameterDB)` database entries. The object
-#' is tagged with the class attribute `<epiparamterDB>` to validate the
+#' is tagged with the class attribute `<epiparameterDB>` to validate the
 #' parameter library has been loaded using the `{epiparameterDB}` package.
 #'
 "epiparameterDB"

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 # `{epiparameterDB}` <img src="man/figures/logo.svg" align="right" width="120" alt="" />
 
 <!-- badges: start -->
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/mit)
+[![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-violet.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 [![R-CMD-check](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/epiparameterDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameterDB?branch=main)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <!-- badges: start -->
 
 [![License:
-MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/mit)
+CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-violet.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 [![R-CMD-check](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/epiparameterDB/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/epiparameterDB/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameterDB?branch=main)
@@ -119,7 +119,7 @@ languages, but also differs from them in the following aspects:
 citation("epiparameterDB")
 #> To cite package 'epiparameterDB' in publications use:
 #> 
-#>   Lambert J, Kucharski A, Tamayo Cuartero C (2025). _epiparameterDB:
+#>   Lambert J, Kucharski A, Tamayo Cuartero C (2026). _epiparameterDB:
 #>   Database of Epidemiological Parameters_. R package version
 #>   0.1.0.9000, <https://github.com/epiverse-trace/epiparameterDB/>.
 #> 
@@ -128,7 +128,7 @@ citation("epiparameterDB")
 #>   @Manual{,
 #>     title = {epiparameterDB: Database of Epidemiological Parameters},
 #>     author = {Joshua W. Lambert and Adam Kucharski and Carmen {Tamayo Cuartero}},
-#>     year = {2025},
+#>     year = {2026},
 #>     note = {R package version 0.1.0.9000},
 #>     url = {https://github.com/epiverse-trace/epiparameterDB/},
 #>   }

--- a/man/epiparameterDB.Rd
+++ b/man/epiparameterDB.Rd
@@ -9,7 +9,7 @@
 
 A \code{list} of epidemiological parameters read from \code{extdata/parameters.json}
 with 133 database entries. The object
-is tagged with the class attribute \verb{<epiparamterDB>} to validate the
+is tagged with the class attribute \verb{<epiparameterDB>} to validate the
 parameter library has been loaded using the \code{{epiparameterDB}} package.
 }
 }


### PR DESCRIPTION
This PR contains various minor updates to the package, including:

* Update the `validate-json.yaml` workflow trigger from `sysdata.rda` to `data/**`
* Update pipe linter to base R pipe (`|>`)
* Remove Rcpp and Stan linter exclusions to simplify `.lintr` file, as this package will not use Rcpp or Stan
* Fix typo in `data.R` documentation
* Fix license badge in `README` from MIT to CC0

This PR does not contain any functional changes.